### PR TITLE
修复多处bug提升协议的稳定性。建议发布版本为v1.2.0

### DIFF
--- a/mqttclient/mqttclient.h
+++ b/mqttclient/mqttclient.h
@@ -118,7 +118,6 @@ typedef struct mqtt_client {
     mqtt_list_t                 mqtt_ack_handler_list;
     network_t                   *mqtt_network;
     platform_thread_t           *mqtt_thread;
-    platform_timer_t            mqtt_reconnect_timer;
     platform_timer_t            mqtt_last_sent;
     platform_timer_t            mqtt_last_received;
     reconnect_handler_t         mqtt_reconnect_handler;

--- a/network/nettype_tls.c
+++ b/network/nettype_tls.c
@@ -207,7 +207,7 @@ int nettype_tls_write(network_t *n, unsigned char *buf, int len, int timeout)
     
     nettype_tls_params_t *nettype_tls_params = (nettype_tls_params_t *) n->nettype_tls_params;
 
-    platform_timer_init(&timer);
+    
     platform_timer_cutdown(&timer, timeout);
 
     do {
@@ -235,7 +235,7 @@ int nettype_tls_read(network_t *n, unsigned char *buf, int len, int timeout)
     
     nettype_tls_params_t *nettype_tls_params = (nettype_tls_params_t *) n->nettype_tls_params;
 
-    platform_timer_init(&timer);
+    
     platform_timer_cutdown(&timer, timeout);
     
     do {

--- a/network/network.c
+++ b/network/network.c
@@ -75,7 +75,6 @@ void network_release(network_t* n)
     if (n->socket >= 0)
         network_disconnect(n);
 
-    memset(n, 0, sizeof(network_t));
 }
 
 void network_set_channel(network_t *n, int channel)

--- a/platform/RT-Thread/platform_thread.c
+++ b/platform/RT-Thread/platform_thread.c
@@ -15,56 +15,51 @@ platform_thread_t *platform_thread_init( const char *name,
                                         unsigned int priority,
                                         unsigned int tick)
 {
-    rt_err_t err;
     platform_thread_t *thread;
-    uint8_t *thread_stack;
 
     thread = platform_memory_alloc(sizeof(platform_thread_t));
 
-    thread_stack = (uint8_t*) platform_memory_alloc(stack_size);
-
-    err =  rt_thread_init(&(thread->thread),
-                            (const char *)name,
-                                         entry,
-                                         param,
-                                         thread_stack,
-                                         stack_size,
-                                         priority,
-                                         tick);
-    if(err != RT_EOK) {
-        platform_memory_free(thread);
-        platform_memory_free(thread_stack);
-        return NULL;
+    if(RT_NULL == thread)
+    {
+        return RT_NULL;
     }
 
+    /*modify thread creation method is dynamic creation, so thread exit rtos can recylcle the resource!*/
+    thread->thread = rt_thread_create((const char *)name,
+        entry, param,
+        stack_size, priority, tick);
+    
+    if (thread->thread == RT_NULL)
+    {
+        return RT_NULL;    
+    }
+    else
+    {
+        return thread;    
+    }
 
-    return thread;
 }
 
 void platform_thread_startup(platform_thread_t* thread)
 {
-    rt_thread_startup(&(thread->thread));
+    rt_thread_startup(thread->thread);
 }
 
 
 void platform_thread_stop(platform_thread_t* thread)
 {
-    rt_thread_suspend(&(thread->thread));
-    rt_schedule();
+    rt_thread_suspend(thread->thread);
+    
 }
 
 void platform_thread_start(platform_thread_t* thread)
 {
-    rt_thread_resume(&(thread->thread));
+    rt_thread_resume(thread->thread);
 }
 
 void platform_thread_destroy(platform_thread_t* thread)
 {
-    if (NULL != thread)
-        rt_thread_detach(&(thread->thread));
-
-    platform_memory_free(&(thread->thread));
-    platform_memory_free(&(thread->thread.stack_addr));
+    platform_memory_free(thread);
 }
 
 

--- a/platform/RT-Thread/platform_thread.h
+++ b/platform/RT-Thread/platform_thread.h
@@ -11,7 +11,7 @@
 #include <rtthread.h>
 
 typedef struct platform_thread {
-    struct rt_thread thread;
+    rt_thread_t thread;
 } platform_thread_t;
 
 platform_thread_t *platform_thread_init( const char *name,


### PR DESCRIPTION
platform_thread.c函数中的创建线程，删除线程的方式存在使用已经释放的内存的问题，修改platform_thread_init函数内部采用rt_thread_creat方式创建 ，线程释放时调用的platform_thread_destroy函数置释放申请的管理线程指针
2、platform_timer_init(&timer);
    platform_timer_cutdown(&timer, c->mqtt_cmd_timeout);这两个函数都是对同一变量进行赋值，在所有调用的函数中去除第一个函数，删除第一个函数

3、mqtt_connect_with_results，内部申请的发送与接收缓冲区放到mqtt_lease函数中进行。解决多次重新连接导致的内存泄漏
        连接失败时，不执行释放platform_memory_free(c->mqtt_network),方便下次接着使用。
       1025行启动函数只执行一次就可以，删除下和行的。
       增加创建线程失败的打印，位于1031行，同时断开链接

4、ack list链表的写入访问采用c->mqtt_write_lock信号量来进行保护， mqtt_publish_packet_handle函数中的调用mqtt_ack_list_record未进行保护，采用互斥信号量进行保护

5、mqtt_ack_list_unrecord函数对链表的操作没有被c->mqtt_write_lock未进行保护，已经修改

6、mqtt连接断开再重连时，出现内存耗用增加64字节-128字节不等的情况。这时由于断开重新连接网络后mqtt_subscribe函数重新订阅，申请的内存导致的，这里的链表的处理导致内存泄漏了。

说明：修改了3，6的内存泄漏的地方后，第一次连接网络后，占用动态内存为22616，断开网线后，再次连网动态内存占用22620，之后测试三次断开再连接动态内存占用为22620。也就是说第二次以后，内存占用多了4个字节。
         修改了4， 即对所有链表操作地方增加了互斥信号量保护后，第一次连接网络后，占用动态内存为22616，断开网线后，再次连网动态内存占用22616，后面又进行了三次断网，连接后，内存占用22616。动态内存保持稳定了。

7、需要在mqtt重新连接网络之前，设置一个回调函数，用于更新连接的password，因为onenet平台连接需要支持动态密钥的方式，密钥与时间相关联并且发生变化 。解决方法：原来程序的mqtt_reconnect_handler的回调函数，进行连接前的重新回调用。删除程序中重连定时器变量,只使用重新连接的周期变量。