### PR TITLE
解决个别异常网络情况下的稳定性

### DIFF
--- a/mqttclient/mqttclient.c
+++ b/mqttclient/mqttclient.c
@@ -1292,6 +1292,11 @@ int mqtt_disconnect(mqtt_client_t* c)
     
     platform_timer_cutdown(&timer, c->mqtt_cmd_timeout);
 
+    if (CLIENT_STATE_CONNECTED != mqtt_get_client_state(c))
+    {
+        return KAWAII_MQTT_SUCCESS_ERROR;
+    }
+
     platform_mutex_lock(&c->mqtt_write_lock);
 
     /* serialize disconnect packet and send it */

--- a/mqttclient/mqttclient.h
+++ b/mqttclient/mqttclient.h
@@ -61,6 +61,7 @@ typedef struct message_data {
 typedef void (*interceptor_handler_t)(void* client, message_data_t* msg);
 typedef void (*message_handler_t)(void* client, message_data_t* msg);
 typedef void (*reconnect_handler_t)(void* client, void* reconnect_date);
+typedef void (*connect_handler_t)(void* client, void* connect_date);
 
 typedef struct message_handlers {
     mqtt_list_t         list;
@@ -94,6 +95,7 @@ typedef struct mqtt_client {
     char                        *mqtt_port;
     char                        *mqtt_ca;
     void                        *mqtt_reconnect_data;
+    void                        *mqtt_connect_data;
     uint8_t                     *mqtt_read_buf;
     uint8_t                     *mqtt_write_buf;
     uint16_t                    mqtt_keep_alive_interval;
@@ -122,6 +124,7 @@ typedef struct mqtt_client {
     platform_timer_t            mqtt_last_received;
     reconnect_handler_t         mqtt_reconnect_handler;
     interceptor_handler_t       mqtt_interceptor_handler;
+    connect_handler_t           mqtt_connect_handler;
 } mqtt_client_t;
 
 
@@ -156,6 +159,8 @@ KAWAII_MQTT_CLIENT_SET_STATEMENT(write_buf_size, uint32_t)
 KAWAII_MQTT_CLIENT_SET_STATEMENT(reconnect_try_duration, uint32_t)
 KAWAII_MQTT_CLIENT_SET_STATEMENT(reconnect_handler, reconnect_handler_t)
 KAWAII_MQTT_CLIENT_SET_STATEMENT(interceptor_handler, interceptor_handler_t)
+KAWAII_MQTT_CLIENT_SET_STATEMENT(connect_data, void*)
+KAWAII_MQTT_CLIENT_SET_STATEMENT(connect_handler, connect_handler_t)
 
 void mqtt_sleep_ms(int ms);
 mqtt_client_t *mqtt_lease(void);

--- a/network/nettype_tcp.c
+++ b/network/nettype_tcp.c
@@ -29,7 +29,10 @@ int nettype_tcp_connect(network_t* n)
 
 void nettype_tcp_disconnect(network_t* n)
 {
-    if (NULL != n)
+    if((NULL != n) && (n->socket >= 0))
+    {  
         platform_net_socket_close(n->socket);
-    n->socket = -1;
+        n->socket = -1;
+    }
+
 }

--- a/platform/RT-Thread/platform_memory.c
+++ b/platform/RT-Thread/platform_memory.c
@@ -10,9 +10,12 @@
 
 void *platform_memory_alloc(size_t size)
 {
-    char *ptr;
+    char *ptr = RT_NULL;
     ptr = rt_malloc(size);
-    memset(ptr, 0, size);
+    if(ptr)
+    {
+        memset(ptr, 0, size);
+    }
     return (void *)ptr;
 }
 

--- a/test/test.c
+++ b/test/test.c
@@ -34,7 +34,7 @@ static int mqtt_publish_handle1(mqtt_client_t *client)
 }
 
 
-int main(void)
+int main_mqtt(void)
 {
     mqtt_client_t *client = NULL;
     


### PR DESCRIPTION
1、解决服务器断开连接情况下，mqtt客户端不释放socket资源导致的socket文件句柄用尽的问题
2、优化个别地方的LOG打印信息，正常输出的信息使用LOG_I级别，错误信息使用LOG_E