### PR TITLE
[update] Update the test program

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -33,8 +33,8 @@ static int mqtt_publish_handle1(mqtt_client_t *client)
     return mqtt_publish(client, "rtt-topic", &msg);
 }
 
-
-int main(void)
+static char cid[64] = { 0 };
+static void kawaii_mqtt_demo(void *parameter)
 {
     mqtt_client_t *client = NULL;
     
@@ -44,12 +44,16 @@ int main(void)
 
     client = mqtt_lease();
 
-    mqtt_set_host(client, "www.jiejie01.top");
+    rt_snprintf(cid, sizeof(cid), "rtthread%d", rt_tick_get());
+
+    mqtt_set_host(client, "jiejie01.top");
     mqtt_set_port(client, "1883");
     mqtt_set_user_name(client, "rt-thread");
     mqtt_set_password(client, "rt-thread");
-    mqtt_set_client_id(client, "rt-thread");
+    mqtt_set_client_id(client, cid);
     mqtt_set_clean_session(client, 1);
+
+    KAWAII_MQTT_LOG_I("The ID of the Kawaii client is: %s ",cid);
 
     mqtt_connect(client);
     
@@ -61,3 +65,18 @@ int main(void)
         mqtt_sleep_ms(4 * 1000);
     }
 }
+
+int ka_mqtt(void)
+{
+    rt_thread_t tid_mqtt;
+
+    tid_mqtt = rt_thread_create("kawaii_demo", kawaii_mqtt_demo, RT_NULL, 2048, 17, 10);
+    if (tid_mqtt == RT_NULL) {
+        return -RT_ERROR;
+    }
+
+    rt_thread_startup(tid_mqtt);
+
+    return RT_EOK;
+}
+MSH_CMD_EXPORT(ka_mqtt, Kawaii MQTT client test program);

--- a/test/test.c
+++ b/test/test.c
@@ -30,7 +30,7 @@ static int mqtt_publish_handle1(mqtt_client_t *client)
     msg.qos = QOS0;
     msg.payload = (void *)"this is a kawaii mqtt test ...";
 
-    return mqtt_publish(client, "rtt-topic", &msg);
+    return mqtt_publish(client, "rtt-pub", &msg);
 }
 
 static char cid[64] = { 0 };
@@ -57,7 +57,7 @@ static void kawaii_mqtt_demo(void *parameter)
 
     mqtt_connect(client);
     
-    mqtt_subscribe(client, "rtt-topic", QOS0, sub_topic_handle1);
+    mqtt_subscribe(client, "rtt-sub", QOS0, sub_topic_handle1);
     
     while (1) {
         mqtt_publish_handle1(client);


### PR DESCRIPTION
更新测试程序，解决以下问题：
1. 测试程序的函数名为 `main` 如果用户直接在软件包中开启测试程序，则会编译报错，现改为命令行中去穿件一个线程的方式
2. 通过获取 `tick` 作为 `client` 的名字，这样能保证同一时间多人测试，几乎不可能出现客户端名字一致的情况
3. 更新测试 `MQTT` 服务器的域名