### PR TITLE
identifier "FIONBIO" is undefined 解决这个报错

### DIFF
--- a/platform/RT-Thread/platform_net_socket.h
+++ b/platform/RT-Thread/platform_net_socket.h
@@ -15,6 +15,7 @@
 
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <sys/ioctl.h>
 #include <sal_socket.h>
 #include <netdb.h>
 #include <sal_netdb.h>


### PR DESCRIPTION
可能由于RT-Thread版本的变更，导致现在直接编译kawaii-mqtt软件包出现无法找到FIONBIO这个宏定义。
![image](https://user-images.githubusercontent.com/64183082/236608113-f2c25f9c-7a0f-443b-96c8-1fe3ba63da8b.png)

![image](https://user-images.githubusercontent.com/64183082/236607925-e0f5583d-4b92-415b-8d44-209969956e37.png)
